### PR TITLE
Add option to skip title patcher when loading module

### DIFF
--- a/source/main.c
+++ b/source/main.c
@@ -87,7 +87,7 @@ int main(int argc, char** argv)
 
     if (status.hold & VPAD_BUTTON_ZL)
     {
-        log("Nimble patches skipped.");
+        log("Nimble patches and title patcher install skipped.");
     }
     else
     {
@@ -111,12 +111,12 @@ int main(int argc, char** argv)
         {
             log("Nimble patches failed!");
         }
-    }
 
-    log("Installing title patcher...");
-    ret = install_title_patcher();
-    if (ret < 0) {
-        log("Title patcher install failed!");
+        log("Installing title patcher...");
+        ret = install_title_patcher();
+        if (ret < 0) {
+            log("Title patcher install failed!");
+        }
     }
 
 #ifdef DEBUG


### PR DESCRIPTION
Same as before just hold ZL on the gamepad while the module is loading and both the Nimble patches and the title patcher install will be skipped!